### PR TITLE
Feature/avoid deletion of areas with department admins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 ruby RUBY_VERSION
 
@@ -15,18 +15,19 @@ gemspec
 # your gem to rubygems.org.
 
 group :development, :test do
-  gem "byebug", "~> 10.0", platform: :mri
-  gem "bootsnap"
-  gem "social-share-button"
-  gem "faker", "~> 1.9"
-  gem "decidim"
-  gem "rubocop-rspec"
+  gem 'bootsnap'
+  gem 'byebug', '~> 10.0', platform: :mri
+  gem 'decidim', git: 'https://github.com/decidim/decidim.git'
+  gem 'faker', '~> 1.9'
+  gem 'social-share-button'
+  # gem 'decidim'
+  gem 'rubocop-rspec'
 end
 
 group :development do
-  gem "letter_opener_web", "~> 1.3"
-  gem "listen", "~> 3.1"
-  gem "spring", "~> 2.0"
-  gem "spring-watcher-listen", "~> 2.0"
-  gem "web-console", "~> 3.5"
+  gem 'letter_opener_web', '~> 1.3'
+  gem 'listen', '~> 3.1'
+  gem 'spring', '~> 2.0'
+  gem 'spring-watcher-listen', '~> 2.0'
+  gem 'web-console', '~> 3.5'
 end

--- a/app/decorators/decidim/area_decorator.rb
+++ b/app/decorators/decidim/area_decorator.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_dependency 'decidim/area'
+
+Decidim::Area.class_eval do
+  before_destroy :abort_if_department_admins
+
+  def has_department_admins?
+    Decidim::User.where(organization: organization).any? do |u|
+      u.areas.exists?(id)
+    end
+  end
+
+  def abort_if_department_admins
+    throw(:abort) if has_department_admins?
+  end
+end

--- a/decidim-department_admin.gemspec
+++ b/decidim-department_admin.gemspec
@@ -1,27 +1,27 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.push File.expand_path("lib", __dir__)
+$LOAD_PATH.push File.expand_path('lib', __dir__)
 
-require "decidim/department_admin/version"
+require 'decidim/department_admin/version'
 
-DECIDIM_VER= '>= 0.16.1'
+DECIDIM_VER = '>= 0.16.1'
 
 Gem::Specification.new do |s|
   s.version = Decidim::DepartmentAdmin.version
-  s.authors = ["Oliver Valls"]
-  s.email = ["oliver.vh@coditramuntana.com"]
-  s.license = "AGPL-3.0"
-  s.homepage = "https://github.com/decidim/decidim-module-department_admin"
-  s.required_ruby_version = ">= 2.5"
+  s.authors = ['Oliver Valls']
+  s.email = ['oliver.vh@coditramuntana.com']
+  s.license = 'AGPL-3.0'
+  s.homepage = 'https://github.com/decidim/decidim-module-department_admin'
+  s.required_ruby_version = '>= 2.5'
 
-  s.name = "decidim-department_admin"
-  s.summary = "A decidim department_admin module"
+  s.name = 'decidim-department_admin'
+  s.summary = 'A decidim department_admin module'
   s.description = "This Dedicim's module produces a new \"department admin\" role which restricts the permissions of an Admin into participatory spaces of a given Area."
 
-  s.files = Dir["{app,config,lib}/**/*", "LICENSE-AGPLv3.txt", "Rakefile", "README.md"]
-  s.test_files = Dir["spec/**/*"]
+  s.files = Dir['{app,config,lib}/**/*', 'LICENSE-AGPLv3.txt', 'Rakefile', 'README.md']
+  s.test_files = Dir['spec/**/*']
 
-  s.add_dependency "decidim-core", DECIDIM_VER
-  s.add_development_dependency "decidim", DECIDIM_VER
-  s.add_development_dependency "decidim-dev", DECIDIM_VER
+  s.add_dependency 'decidim-core', DECIDIM_VER
+  s.add_development_dependency 'decidim', DECIDIM_VER
+  s.add_development_dependency 'decidim-dev', DECIDIM_VER
 end

--- a/spec/models/decidim/area_spec.rb
+++ b/spec/models/decidim/area_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Decidim
+  describe Area do
+    subject(:area) { create(:area) }
+
+    context 'when depending participatory process exist' do
+      let!(:department_admin) do
+        user = create(:user, :confirmed, organization: area.organization)
+        user.roles << 'department_admin'
+        user.areas << area
+        user.save!
+        user
+      end
+
+      it 'can not be deleted' do
+        expect(area.destroy).to be false
+      end
+    end
+  end
+end

--- a/spec/system/admin_invite_department_admin_spec.rb
+++ b/spec/system/admin_invite_department_admin_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require 'spec_helper'
 
-describe "Admin invite user as department admin", type: :system do
+describe 'Admin invite user as department admin', type: :system do
   let!(:area) { create(:area) }
 
   let(:organization) { create(:organization) }
@@ -16,15 +16,15 @@ describe "Admin invite user as department admin", type: :system do
     visit decidim_admin.new_user_path
   end
 
-  it "admin is successfully created" do
-    fill_the_form("Cabello Loco", "my@email.net")
+  it 'admin is successfully created' do
+    fill_the_form('Cabello Loco', 'my@email.net')
     submit_form
     check_succeess
     check_is_department_admin('my@email.net')
     check_assigned_area(@user, area)
   end
 
-  it "admin is able to add department_admin to existing user" do
+  it 'admin is able to add department_admin to existing user' do
     fill_the_form(user_manager.name, user_manager.email)
     submit_form
     check_succeess
@@ -32,9 +32,9 @@ describe "Admin invite user as department admin", type: :system do
     check_assigned_area(user_manager, area)
   end
 
-  context "when departments are reorganized" do
+  context 'when departments are reorganized' do
     let(:department_admin) do
-      user= create(:user, :confirmed, organization: organization)
+      user = create(:user, :confirmed, organization: organization)
       user.roles << 'department_admin'
       user.areas << area
       user.save!
@@ -43,7 +43,7 @@ describe "Admin invite user as department admin", type: :system do
     let!(:new_area) { create(:area) }
 
     before { visit decidim_admin.new_user_path }
-    
+
     it "admin is able to change department_admin's area/department" do
       fill_the_form(department_admin.name, department_admin.email, new_area)
       submit_form
@@ -53,25 +53,29 @@ describe "Admin invite user as department admin", type: :system do
     end
   end
 
-  def fill_the_form(name, email, selected_area=area)
-    within "form.new_user" do
+  def fill_the_form(name, email, selected_area = area)
+    within 'form.new_user' do
       fill_in :user_name, with: name
       fill_in :user_email, with: email
       find('#user_role').find("option[value='department_admin']").select_option
       find('#user_area_id').find("option[value='#{selected_area.id}']").select_option
     end
   end
+
   def submit_form
-    find("*[name=commit][type=submit]").click
+    find('*[name=commit][type=submit]').click
   end
+
   def check_succeess
-    expect(page).to have_content("Participant successfully invited.")
-    expect(page).to have_current_path "/admin/users"
+    expect(page).to have_content('Participant successfully invited.')
+    expect(page).to have_current_path '/admin/users'
   end
+
   def check_is_department_admin(email)
-    @user= Decidim::User.find_by_email(email)
+    @user = Decidim::User.find_by_email(email)
     expect(@user.roles).to include('department_admin')
   end
+
   def check_assigned_area(user, area)
     expect(user.areas.last).to eq(area)
   end


### PR DESCRIPTION
When an Area has department_admins associated to it, it should not allow to be destroyed.

- [x] tests
- [x] devel
- [ ] Reference `decidim` gem, not `decidim` git repo.