### PR TITLE
Hack Decidim::User::ROLES.freeze

### DIFF
--- a/app/decorators/decidim/user_decorator.rb
+++ b/app/decorators/decidim/user_decorator.rb
@@ -6,8 +6,6 @@
 # - adds required associations between User and Area.
 #
 
-Decidim::User::ROLES = %w[admin department_admin user_manager].freeze
-
 require_dependency 'decidim/user'
 Decidim::User.class_eval do
   has_and_belongs_to_many :areas,
@@ -20,3 +18,12 @@ Decidim::User.class_eval do
     role?('department_admin')
   end
 end
+require 'fiddle'
+
+class Object
+  def unfreeze
+    Fiddle::Pointer.new(object_id * 2)[1] &= ~(1 << 3)
+  end
+end
+Decidim::User::ROLES.unfreeze
+Decidim::User::ROLES << 'department_admin'


### PR DESCRIPTION
Do not overwrite Decidim::User::ROLES, instead add department_admin role to the list.

It is now using a hack that un freezes the ROLES array.

I've made [this PR](https://github.com/decidim/decidim/pull/5133) in order to not having to do this hack in the future but instead simply add the new role to the array.