### PR TITLE
Make decidim-department-admin compatible with Decidim v0.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project is in BETA, but going to be tested in production.
 
 ## next version:
 
+## Version 0.0.12 (PATCH)
+- FIX: Change method name: `organization_assemblies` to `collection`.
+
 ## Version 0.0.11 (PATCH)
 - Add :index permission for department_admins to add assembly administrators (assembly_user_role).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project is in BETA, but going to be tested in production.
 
 ## Version 0.0.12 (PATCH)
 - FIX: Change method name: `organization_assemblies` to `collection`.
+- Make gem compatible with Decidim v0.21.0.
 
 ## Version 0.0.11 (PATCH)
 - Add :index permission for department_admins to add assembly administrators (assembly_user_role).

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ gemspec
 group :development, :test do
   gem 'bootsnap'
   gem 'byebug', platform: :mri
-  gem 'decidim', git: 'https://github.com/decidim/decidim.git', branch: '0.18-stable'
   gem 'faker', '~> 1.9'
   gem 'social-share-button'
   # gem 'decidim'

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ group :development, :test do
   gem 'byebug', platform: :mri
   gem 'faker', '~> 1.9'
   gem 'social-share-button'
-  # gem 'decidim'
+  gem 'decidim'
   gem 'rubocop-rspec'
 end
 

--- a/app/decorators/decidim/assemblies/admin/assemblies_controller_decorator.rb
+++ b/app/decorators/decidim/assemblies/admin/assemblies_controller_decorator.rb
@@ -7,11 +7,11 @@
 Decidim::Assemblies::Admin::AssembliesController.class_eval do
   private
 
-  alias_method :original_organization_assemblies, :organization_assemblies
+  alias_method :original_organization_assemblies, :collection
 
-  def organization_assemblies
-    query= original_organization_assemblies
-    query= query.where('decidim_area_id' => current_user.areas.pluck(:id)) if current_user&.department_admin?
+  def collection
+    query = original_organization_assemblies
+    query = query.where(decidim_area_id: current_user.areas.pluck(:id)) if current_user&.department_admin?
     query
   end
 end

--- a/decidim-department_admin.gemspec
+++ b/decidim-department_admin.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.push File.expand_path('lib', __dir__)
 
 require 'decidim/department_admin/version'
 
-DECIDIM_VER = '>= 0.16.1'
+DECIDIM_VER = '>= 0.21.0'
 
 Gem::Specification.new do |s|
   s.version = Decidim::DepartmentAdmin.version

--- a/lib/decidim/department_admin/version.rb
+++ b/lib/decidim/department_admin/version.rb
@@ -5,7 +5,7 @@ module Decidim
   module DepartmentAdmin
     # see CHANGELOG.md
     def self.version
-      '0.0.11'
+      '0.0.12'
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Upgrade decidim-department-admin so it can work with decidim latest version.

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Update overwritten files