### PR TITLE
Fix admin user profile's detail view

### DIFF
--- a/app/decorators/decidim/admin/users_controller_decorator.rb
+++ b/app/decorators/decidim/admin/users_controller_decorator.rb
@@ -41,7 +41,7 @@ require_dependency 'decidim/admin/users_controller'
       if process_title == '' then
         process_title = process.title["ca"]
       end
-      byebug
+
       @spaces.push({"title" => process_title,
                     "type" => type,
                     "area" => process.area.nil? ? "" : process.area&.name[locale],

--- a/app/decorators/decidim/admin/users_controller_decorator.rb
+++ b/app/decorators/decidim/admin/users_controller_decorator.rb
@@ -31,26 +31,27 @@ require_dependency 'decidim/admin/users_controller'
       if process.participatory_process_group then
         if process.participatory_process_group&.name[locale] != '' then
           type = process.participatory_process_group&.name[locale]
-        else 
+        else
           type = process.participatory_process_group&.name["ca"]
         end
-      else 
+      else
         type = t("models.user.fields.process_type", scope: "decidim.admin")
       end
       process_title = process.title[locale]
       if process_title == '' then
         process_title = process.title["ca"]
       end
+      byebug
       @spaces.push({"title" => process_title,
                     "type" => type,
-                    "area" => process.area&.name[locale],
+                    "area" => process.area.nil? ? "" : process.area&.name[locale],
                     "created_at" => process.created_at,
                     "private" => process.private_space?,
                     "published" => process.published?})
     end
 
     @user.assemblies.each do |assembly|
-      
+
       if assembly.area && assembly.area.name then
         area_name = assembly.area.name[locale]
       else
@@ -62,7 +63,7 @@ require_dependency 'decidim/admin/users_controller'
         assembly_title = assembly.title["ca"]
       end
 
-      @spaces.push({"title" => assembly_title, 
+      @spaces.push({"title" => assembly_title,
                     "type" => t("models.user.fields.assembly_type", scope: "decidim.admin"),
                     "area" => area_name,
                     "created_at" => assembly.created_at,
@@ -82,7 +83,7 @@ require_dependency 'decidim/admin/users_controller'
       @spaces.sort! {|x, y| y["title"] <=> x["title"]}
     end
   end
-  
+
   def sort_spaces(column, order)
     @spaces.sort! {|x, y| x[column] <=> y[column]}.reverse
   end


### PR DESCRIPTION
### Purpose

As you're logged in as an admin, when you want to access to user's processes, you got an error.

#### How to replicate

1. Login as an admin
2. Click on "Users" menu's option on left
3. In users list, click on the right "eye" icon of whatever user
4. See error

### :camera: Screenshots

![image](https://user-images.githubusercontent.com/9702463/93764871-2fd11b00-fc14-11ea-806b-963d73c9ca3b.png)

