### PR TITLE
Fix missing area when creating first organization user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project is in BETA, but going to be tested in production.
 
 ## next version:
 
+## Version 0.1.0 (MINOR)
+- Increase minimum Decidim version to v0.22
+- Add some documentation regarding the invitation of admins.
+- Fix do not require an area to exist to invite new admins.
+
 ## Version 0.0.16 (MINOR)
 - A user can only belong to one single department. [\#30](https://github.com/gencat/decidim-department-admin/pull/30)
 - When a department_admin is promoted to admin, she looses the role and the department. [\#30](https://github.com/gencat/decidim-department-admin/pull/30)

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ ruby RUBY_VERSION
 
 gemspec
 
+DECIDIM_VERSION= { git: "https://github.com/gencat/decidim", branch: "release/0.22-stable" }.freeze
+
 # Bundler will treat runtime dependencies like base dependencies, and
 # development dependencies will be added by default to the :development group.
 
@@ -19,7 +21,7 @@ group :development, :test do
   gem 'byebug', platform: :mri
   gem 'faker', '~> 1.9'
   gem 'social-share-button'
-  gem 'decidim'
+  gem 'decidim', DECIDIM_VERSION
   gem 'rubocop-rspec'
 end
 

--- a/app/decorators/decidim/invite_user_form_decorator.rb
+++ b/app/decorators/decidim/invite_user_form_decorator.rb
@@ -15,6 +15,6 @@ Decidim::InviteUserForm.class_eval do
   # called from the command
   # returns the selected Decidim::Area instance.
   def selected_area
-    Decidim::Area.find(area_id)
+    Decidim::Area.find_by_id(area_id)
   end
 end

--- a/decidim-department_admin.gemspec
+++ b/decidim-department_admin.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.push File.expand_path('lib', __dir__)
 
 require 'decidim/department_admin/version'
 
-DECIDIM_VER = '>= 0.21.0'
+DECIDIM_VER = '>= 0.22.0'
 
 Gem::Specification.new do |s|
   s.version = Decidim::DepartmentAdmin.version

--- a/lib/decidim/department_admin/version.rb
+++ b/lib/decidim/department_admin/version.rb
@@ -5,7 +5,7 @@ module Decidim
   module DepartmentAdmin
     # see CHANGELOG.md
     def self.version
-      '0.0.16'
+      '0.0.17'
     end
   end
 end

--- a/spec/commands/decidim/invite_user_spec.rb
+++ b/spec/commands/decidim/invite_user_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Decidim
+  describe InviteUser do
+    describe 'call' do
+      let(:organization) { create(:organization) }
+
+      let(:current_user) { create(:admin, :confirmed, organization: organization) }
+
+      let(:form_params) do
+        {
+          name: 'user_name',
+          email: 'user_name@example.org',
+          organization: organization
+        }
+      end
+
+      let(:form) do
+        InviteUserForm.from_params(
+          form_params
+        ).with_context(
+          current_organization: organization,
+          current_user: current_user
+        )
+      end
+
+      let(:command) { described_class.new(form, current_user) }
+
+      shared_examples_for 'inviting_users' do
+        context 'when everything is ok' do
+          it 'invites the user with no area' do
+            invite_user
+            user = Decidim::User.find_by(email: 'user_name@example.org')
+            expect(user).to exist
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/system/admin_invite_department_admin_spec.rb
+++ b/spec/system/admin_invite_department_admin_spec.rb
@@ -2,6 +2,10 @@
 
 require 'spec_helper'
 
+#
+# To "downgrade" an admin to department_admin, it must first be removed from admins
+# create a new admin as department_admin.
+#
 describe 'Admin invite user', type: :system do
   let!(:area) { create(:area) }
 

--- a/spec/system/department_admin_should_be_able_to_see_only_assemblies_from_her_area_spec.rb
+++ b/spec/system/department_admin_should_be_able_to_see_only_assemblies_from_her_area_spec.rb
@@ -18,12 +18,12 @@ describe 'Admin manages assemblies', versioning: true, type: :system do
 
   it 'should see the import button' do
     visit_admin_assemblies_list
-    expect(page)to have_content("Import")
+    expect(page).to have_content("Import")
   end
 
   it 'should see the export button' do
     visit_admin_assemblies_list
-    expect(page)to have_css("icon--data-transfer-download")
+    expect(page).to have_css("icon--data-transfer-download")
   end
 
   it 'should see only processes in the same area' do

--- a/spec/system/department_admin_should_be_able_to_see_only_processes_from_her_area_spec.rb
+++ b/spec/system/department_admin_should_be_able_to_see_only_processes_from_her_area_spec.rb
@@ -22,12 +22,12 @@ describe 'Admin manages participatory processes', versioning: true, type: :syste
 
   it 'should see the import button' do
     visit_admin_processes_list
-    expect(page)to have_content("Import")
+    expect(page).to have_content("Import")
   end
 
   it 'should see the export button' do
     visit_admin_processes_list
-    expect(page)to have_css("icon--data-transfer-download")
+    expect(page).to have_css("icon--data-transfer-download")
   end
 
   it 'should see only processes in the same area' do


### PR DESCRIPTION
Replace find with find_by_id so it doesn't result in exception when area is missing.