### PR TITLE
Update Decidim version to 0.24.2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -88,7 +88,7 @@ Style/Alias:
     - prefer_alias_method
 
 # Align the elements of a hash literal if they span more than one line.
-Layout/AlignHash:
+Layout/HashAlignment:
   # Alignment of entries using hash rocket as separator. Valid values are:
   #
   # key - left alignment of keys
@@ -151,7 +151,7 @@ Layout/AlignHash:
     - ignore_implicit
     - ignore_explicit
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   # Alignment of parameters in multi-line method calls.
   #
   # The `with_first_parameter` style aligns the following lines along the same
@@ -261,20 +261,6 @@ Style/BlockDelimiters:
     - lambda
     - proc
     - it
-
-Style/BracesAroundHashParameters:
-  EnforcedStyle: no_braces
-  SupportedStyles:
-    # The `braces` style enforces braces around all method parameters that are
-    # hashes.
-    - braces
-    # The `no_braces` style checks that the last parameter doesn't have braces
-    # around it.
-    - no_braces
-    # The `context_dependent` style checks that the last parameter doesn't have
-    # braces around it, but requires braces if the second to last parameter is
-    # also a hash literal.
-    - context_dependent
 
 # Indentation of `when`.
 Layout/CaseIndentation:
@@ -468,7 +454,7 @@ Naming/FileName:
   # files with a shebang in the first line).
   IgnoreExecutableScripts: true
 
-Layout/IndentFirstArgument:
+Layout/FirstArgumentIndentation:
   EnforcedStyle: special_for_inner_method_call_in_parentheses
   SupportedStyles:
     # The first parameter should always be indented one step more than the
@@ -556,7 +542,7 @@ Layout/IndentationWidth:
   Width: 2
 
 # Checks the indentation of the first element in an array literal.
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   # The value `special_inside_parentheses` means that array literals with
   # brackets that have their opening bracket on the same line as a surrounding
   # opening round parenthesis, shall have their first element indented relative
@@ -578,13 +564,13 @@ Layout/IndentFirstArrayElement:
   IndentationWidth: ~
 
 # Checks the indentation of assignment RHS, when on a different line from LHS
-Layout/IndentAssignment:
+Layout/AssignmentIndentation:
   # By default, the indentation width from Style/IndentationWidth is used
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
 # Checks the indentation of the first key in a hash literal.
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   # The value `special_inside_parentheses` means that hash literals with braces
   # that have their opening brace on the same line as a surrounding opening
   # round parenthesis, shall have their first key indented relative to the
@@ -791,12 +777,12 @@ Naming/PredicateName:
     - has_
     - have_
   # Predicate name prefixes that should be removed.
-  NamePrefixBlacklist:
+  ForbiddenPrefixes:
     - is_
     - have_
   # Predicate names which, despite having a blacklisted prefix, or no ?,
   # should still be accepted
-  NameWhitelist:
+  AllowedMethods:
     - is_a?
   # Exclude Rspec specs because there is a strong convetion to write spec
   # helpers in the form of `have_something` or `be_something`.
@@ -977,7 +963,7 @@ Style/TernaryParentheses:
     - require_no_parentheses
   AllowSafeAssignment: true
 
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   EnforcedStyle: final_newline
   SupportedStyles:
     - final_newline
@@ -1028,7 +1014,7 @@ Style/TrivialAccessors:
   # Commonly used in DSLs
   AllowDSLWriters: false
   IgnoreClassMethods: false
-  Whitelist:
+  AllowedMethods:
     - to_ary
     - to_a
     - to_c
@@ -1232,6 +1218,9 @@ RSpec/MessageSpies:
   Enabled: false
 
 RSpec/MultipleExpectations:
+  Enabled: false
+
+RSpec/MultipleMemoizedHelpers:
   Enabled: false
 
 RSpec/NestedGroups:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Following Semantic Versioning 2.
 
 ## next version:
 
+## Version 0.3.0 (MINOR)
+- Increase minimum Decidim version to v0.24.2
+
 ## Version 0.2.0 (MINOR)
 - Allow to perform all actions in Conferences (decidim-conferences).
 - Allow to perform some actions in Participants (decidim-participants).

--- a/Gemfile
+++ b/Gemfile
@@ -15,13 +15,14 @@ DECIDIM_VERSION = { git: "https://github.com/CodiTramuntana/decidim", branch: "r
 # your gemspec. These might include edge Rails or gems from your path or
 # Git. Remember to move these dependencies to your gemspec before releasing
 # your gem to rubygems.org.
+gem "execjs", "~> 2.7.0"
 
 group :development, :test do
   gem "bootsnap"
   gem "byebug", platform: :mri
   gem "decidim", DECIDIM_VERSION
   gem "decidim-conferences", DECIDIM_VERSION
-  gem "faker", "~> 1.9"
+  gem "faker"
   gem "rubocop-rspec"
   gem "social-share-button"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,7 @@ ruby RUBY_VERSION
 
 gemspec
 
-# use CodiTramuntana's fork to get https://github.com/CodiTramuntana/decidim/pull/48 while in 0.23
-DECIDIM_VERSION = { git: "https://github.com/CodiTramuntana/decidim", branch: "release/0.23-stable" }.freeze
+DECIDIM_VERSION = { git: "https://github.com/CodiTramuntana/decidim", branch: "release/0.24-stable" }.freeze
 
 # Bundler will treat runtime dependencies like base dependencies, and
 # development dependencies will be added by default to the :development group.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ bin/rails decidim:generate_external_test_app
 cd spec/decidim_dummy_app/
 bundle exec rails decidim_department_admin:install:migrations
 RAILS_ENV=test bundle exec rails db:migrate
-sed -ie '/^  class Application < Rails::Application/a config.railties_order = [:main_app, ::Decidim::DepartmentAdmin::Engine, :all]' spec/decidim_dummy_app/config/application.rb
+sed -ie '/^  class Application < Rails::Application/a config.railties_order = [:main_app, ::Decidim::DepartmentAdmin::Engine, :all]' config/application.rb
 ```
 
 This last line modifies dummy_app's `config/application.rb` file to enforce railties ordering, adding:

--- a/app/decorators/decidim/assemblies/permissions_decorator.rb
+++ b/app/decorators/decidim/assemblies/permissions_decorator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Decidim::Assemblies::Permissions.class_eval do
+
+  # Intercept the `has_manageable_assemblies?` method
+  # always returns true if the user is a department_admin. Otherwise delegates to the original method.
+  # This is a fix to avoid permissions crashing when there are no assemblies with the user's area.
+  alias_method :original_has_manageable_assemblies?, :has_manageable_assemblies?
+
+  def has_manageable_assemblies?(role: :any)
+    return unless user
+
+    user.department_admin? || original_has_manageable_assemblies?
+  end
+end

--- a/app/decorators/decidim/assemblies/permissions_decorator.rb
+++ b/app/decorators/decidim/assemblies/permissions_decorator.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
 
 Decidim::Assemblies::Permissions.class_eval do
-
   # Intercept the `has_manageable_assemblies?` method
   # always returns true if the user is a department_admin. Otherwise delegates to the original method.
   # This is a fix to avoid permissions crashing when there are no assemblies with the user's area.
   alias_method :original_has_manageable_assemblies?, :has_manageable_assemblies?
 
+  # rubocop: disable Lint/UnusedMethodArgument
   def has_manageable_assemblies?(role: :any)
     return unless user
 
     user.department_admin? || original_has_manageable_assemblies?
   end
+  # rubocop: enable Lint/UnusedMethodArgument
 end

--- a/app/decorators/decidim/conferences/permissions_decorator.rb
+++ b/app/decorators/decidim/conferences/permissions_decorator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Decidim::Conferences::Permissions.class_eval do
+
+  # Intercept the `has_manageable_conferences?` method
+  # always returns true if the user is a department_admin. Otherwise delegates to the original method.
+  # This is a fix to avoid permissions crashing when there are no conferences with the user's area.
+  alias_method :original_has_manageable_conferences?, :has_manageable_conferences?
+
+  def has_manageable_conferences?(role: :any)
+    return unless user
+
+    user.department_admin? || original_has_manageable_conferences?
+  end
+end

--- a/app/decorators/decidim/conferences/permissions_decorator.rb
+++ b/app/decorators/decidim/conferences/permissions_decorator.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
 
 Decidim::Conferences::Permissions.class_eval do
-
   # Intercept the `has_manageable_conferences?` method
   # always returns true if the user is a department_admin. Otherwise delegates to the original method.
   # This is a fix to avoid permissions crashing when there are no conferences with the user's area.
   alias_method :original_has_manageable_conferences?, :has_manageable_conferences?
 
+  # rubocop: disable Lint/UnusedMethodArgument
   def has_manageable_conferences?(role: :any)
     return unless user
 
     user.department_admin? || original_has_manageable_conferences?
   end
+  # rubocop: enable Lint/UnusedMethodArgument
 end

--- a/app/decorators/decidim/newsletters_helper_decorator.rb
+++ b/app/decorators/decidim/newsletters_helper_decorator.rb
@@ -12,6 +12,8 @@ Decidim::Admin::NewslettersHelper.class_eval do
       original_spaces_user_can_admin
     end
   end
+  # rubocop: disable Metrics/CyclomaticComplexity
+  # rubocop: disable Metrics/PerceivedComplexity
 
   def spaces_department_admin_can_admin
     @spaces_user_can_admin ||= {}
@@ -31,4 +33,6 @@ Decidim::Admin::NewslettersHelper.class_eval do
     end
     @spaces_user_can_admin
   end
+  # rubocop: enable Metrics/CyclomaticComplexity
+  # rubocop: enable Metrics/PerceivedComplexity
 end

--- a/app/decorators/decidim/participatory_processes/permissions_decorator.rb
+++ b/app/decorators/decidim/participatory_processes/permissions_decorator.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
 
 Decidim::ParticipatoryProcesses::Permissions.class_eval do
-
   # Intercept the `has_manageable_processes?` method
   # always returns true if the user is a department_admin. Otherwise delegates to the original method.
   # This is a fix to avoid permissions crashing when there are no processes with the user's area.
   alias_method :original_has_manageable_processes?, :has_manageable_processes?
 
+  # rubocop: disable Lint/UnusedMethodArgument
   def has_manageable_processes?(role: :any)
     return unless user
 
     user.department_admin? || original_has_manageable_processes?
   end
+  # rubocop: enable Lint/UnusedMethodArgument
 end

--- a/app/decorators/decidim/participatory_processes/permissions_decorator.rb
+++ b/app/decorators/decidim/participatory_processes/permissions_decorator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Decidim::ParticipatoryProcesses::Permissions.class_eval do
+
+  # Intercept the `has_manageable_processes?` method
+  # always returns true if the user is a department_admin. Otherwise delegates to the original method.
+  # This is a fix to avoid permissions crashing when there are no processes with the user's area.
+  alias_method :original_has_manageable_processes?, :has_manageable_processes?
+
+  def has_manageable_processes?(role: :any)
+    return unless user
+
+    user.department_admin? || original_has_manageable_processes?
+  end
+end

--- a/app/permissions/decidim/department_admin/permissions.rb
+++ b/app/permissions/decidim/department_admin/permissions.rb
@@ -30,7 +30,7 @@ module Decidim
       end
 
       def permissions
-        # byebug if same_action?(permission_action, :admin, :enter, :space_area, space_name: :courses)
+        # byebug if same_action?(permission_action, :admin, :read, :global_moderation)
 
         current_permission_action = permission_action
         if permission_action.scope == :admin && user&.department_admin?

--- a/decidim-department_admin.gemspec
+++ b/decidim-department_admin.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.push File.expand_path("lib", __dir__)
 
 require "decidim/department_admin/version"
 
-DECIDIM_VER = "< 0.24"
+DECIDIM_VER = "~> 0.24.2"
 
 Gem::Specification.new do |s|
   s.version = Decidim::DepartmentAdmin.version

--- a/lib/decidim/department_admin/version.rb
+++ b/lib/decidim/department_admin/version.rb
@@ -5,7 +5,7 @@ module Decidim
   module DepartmentAdmin
     # see CHANGELOG.md
     def self.version
-      "0.2.0"
+      "0.3.0"
     end
   end
 end

--- a/spec/system/department_admin_should_be_able_to_manage_processes_spec.rb
+++ b/spec/system/department_admin_should_be_able_to_manage_processes_spec.rb
@@ -62,7 +62,7 @@ describe "Admin manages participatory processes", versioning: true, type: :syste
           ca: "Descripció més llarga"
         )
 
-        group_name = participatory_process_groups.first.name["en"]
+        group_name = participatory_process_groups.first.title["en"]
         select group_name, from: :participatory_process_participatory_process_group_id
 
         fill_in :participatory_process_slug, with: "slug"


### PR DESCRIPTION
In order to use in Decidim instances with v0.24, the dependency of Decidim now must be ~> 0.24.2

Removed cop doc: https://github.com/rubocop/rubocop/issues/7641