### PR TITLE
Fix use process_group.title instead of .name

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ require: rubocop-rspec
 
 # Common configuration.
 AllCops:
+  NewCops: enable
   Include:
     - .simplecov
     - "**/*.rb"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@ Following Semantic Versioning 2.
 
 ## next version:
 
-## Version 0.3.0 (MINOR)
+## Version 0.3.1 (MINOR)
+- Fixes
+- Add new rubocop cops automatically
+
+## Version 0.3.0 (PATCH)
 - Increase minimum Decidim version to v0.24.2
 
 ## Version 0.2.0 (MINOR)

--- a/app/decorators/decidim/admin/newsletters_controller_decorator.rb
+++ b/app/decorators/decidim/admin/newsletters_controller_decorator.rb
@@ -13,7 +13,7 @@ require_dependency "decidim/admin/newsletters_controller"
 
     @collection ||= Decidim::Newsletter.where(organization: current_organization)
                                        .joins(author: :areas)
-                                       .where("department_admin_areas.decidim_area_id = ?", current_user_areas.pluck(:id))
+                                       .where(department_admin_areas: { decidim_area_id: current_user_areas.pluck(:id) })
   end
 
   def current_user_areas

--- a/app/decorators/decidim/decidim_form_helper_decorator.rb
+++ b/app/decorators/decidim/decidim_form_helper_decorator.rb
@@ -10,9 +10,7 @@ Decidim::DecidimFormHelper.class_eval do
   def areas_for_select(organization)
     author = current_user
 
-    if author&.department_admin?
-      return author.areas if controller_path.split("/").include?("admin")
-    end
+    return author.areas if author&.department_admin? && controller_path.split("/").include?("admin")
 
     original_areas_for_select(organization)
   end

--- a/app/permissions/decidim/department_admin/permissions.rb
+++ b/app/permissions/decidim/department_admin/permissions.rb
@@ -4,13 +4,11 @@ module Decidim
   module DepartmentAdmin
     class Permissions < Decidim::DefaultPermissions
       class << self
-        attr_writer :delegate_chain
-        attr_writer :configurable_checks
+        attr_writer :delegate_chain, :configurable_checks
       end
 
       class << self
-        attr_reader :delegate_chain
-        attr_reader :configurable_checks
+        attr_reader :delegate_chain, :configurable_checks
       end
 
       def delegate_chain

--- a/app/queries/decidim/admin/user_admin_filter.rb
+++ b/app/queries/decidim/admin/user_admin_filter.rb
@@ -23,7 +23,7 @@ module Decidim
         @search_text = search_text
         @role = role
         @current_locale = current_locale
-        super
+        super(scope)
       end
 
       # List the User groups by the diferents filters.

--- a/app/queries/decidim/admin/user_admin_filter.rb
+++ b/app/queries/decidim/admin/user_admin_filter.rb
@@ -23,6 +23,7 @@ module Decidim
         @search_text = search_text
         @role = role
         @current_locale = current_locale
+        super
       end
 
       # List the User groups by the diferents filters.
@@ -82,7 +83,8 @@ module Decidim
       def filter_by_role(users)
         return users unless Decidim::User::Roles.all.include?(role)
 
-        if role == "space_admin"
+        case role
+        when "space_admin"
           if defined?(Decidim::Conferences)
             users.where('"decidim_users"."id" in (select "decidim_participatory_process_user_roles"."decidim_user_id" from "decidim_participatory_process_user_roles")' \
                 ' or "decidim_users"."id" in (select "decidim_assembly_user_roles"."decidim_user_id" from "decidim_assembly_user_roles")' \
@@ -91,7 +93,7 @@ module Decidim
             users.where('"decidim_users"."id" in (select "decidim_participatory_process_user_roles"."decidim_user_id" from "decidim_participatory_process_user_roles")' \
                 ' or "decidim_users"."id" in (select "decidim_assembly_user_roles"."decidim_user_id" from "decidim_assembly_user_roles")')
           end
-        elsif role == "admin"
+        when "admin"
           users.where('"decidim_users"."admin" = ?', true)
         else
           users.where("? = any(roles)", role)

--- a/app/views/decidim/participatory_processes/admin/participatory_processes/index.html.erb
+++ b/app/views/decidim/participatory_processes/admin/participatory_processes/index.html.erb
@@ -13,7 +13,7 @@
 
       <% if process_group %>
         <span>&lt;</span>
-        <%= link_to translated_attribute(process_group.name),
+        <%= link_to translated_attribute(process_group.title),
                     edit_participatory_process_group_path(process_group) %>
       <% end %>
 
@@ -31,9 +31,9 @@
           <%= link_to query_params_with(decidim_participatory_process_group_id_eq: nil) do %>
             <li><%= t("actions.filter.all_processes", scope: "decidim.admin") %></li>
           <% end %>
-          <% process_groups_for_select.each do |group_name, group_id| %>
+          <% process_groups_for_select.each do |group_title, group_id| %>
             <%= link_to query_params_with(decidim_participatory_process_group_id_eq: group_id) do %>
-              <li><%= group_name %></li>
+              <li><%= group_title %></li>
             <% end %>
           <% end %>
         </ul>

--- a/lib/decidim/department_admin/engine.rb
+++ b/lib/decidim/department_admin/engine.rb
@@ -86,7 +86,7 @@ module Decidim
 
       # make decorators available to applications that use this Engine
       config.to_prepare do
-        Dir.glob("#{Decidim::DepartmentAdmin::Engine.root}app/decorators/**/*_decorator*.rb").each do |c|
+        Dir.glob("#{Decidim::DepartmentAdmin::Engine.root}/app/decorators/**/*_decorator*.rb").each do |c|
           require_dependency(c)
         end
       end

--- a/lib/decidim/department_admin/engine.rb
+++ b/lib/decidim/department_admin/engine.rb
@@ -24,6 +24,7 @@ module Decidim
         app.config.assets.precompile += %w(decidim_department_admin_manifest.js decidim_department_admin_manifest.css)
       end
 
+      # rubocop: disable Lint/ConstantDefinitionInBlock
       initializer "department_admin.permissions_registry" do
         # **
         # Modify decidim-admin permissions registry
@@ -81,10 +82,11 @@ module Decidim
           register_new_permissions_for(artifact, ConferencesAdminApplicationControllerPermissions)
         end
       end
+      # rubocop: enable Lint/ConstantDefinitionInBlock
 
       # make decorators available to applications that use this Engine
       config.to_prepare do
-        Dir.glob(Decidim::DepartmentAdmin::Engine.root + "app/decorators/**/*_decorator*.rb").each do |c|
+        Dir.glob("#{Decidim::DepartmentAdmin::Engine.root}app/decorators/**/*_decorator*.rb").each do |c|
           require_dependency(c)
         end
       end

--- a/lib/decidim/department_admin/version.rb
+++ b/lib/decidim/department_admin/version.rb
@@ -5,7 +5,7 @@ module Decidim
   module DepartmentAdmin
     # see CHANGELOG.md
     def self.version
-      "0.3.0"
+      "0.3.1"
     end
   end
 end

--- a/lib/decidim/participatory_space_resourceable.rb
+++ b/lib/decidim/participatory_space_resourceable.rb
@@ -59,9 +59,7 @@ module Decidim
         manifest = Decidim.find_participatory_space_manifest(participatory_space_name)
         return self.class.none unless manifest
 
-        scope = manifest.participatory_spaces.call(organization)
-
-        scope
+        manifest.participatory_spaces.call(organization)
       end
 
       # Links the given resources to this model, replaces any previous links with the same name.

--- a/spec/system/department_admin_should_be_able_to_manage_processes_spec.rb
+++ b/spec/system/department_admin_should_be_able_to_manage_processes_spec.rb
@@ -20,6 +20,15 @@ describe "Admin manages participatory processes", versioning: true, type: :syste
   # it_behaves_like "manage processes examples"
   # it_behaves_like "manage processes announcements"
 
+  context "with processes" do
+    let!(:participatory_process) { create(:participatory_process, organization: organization, area: area, participatory_process_group: participatory_process_groups.first) }
+
+    it "browses the list of processes" do
+      visit decidim_admin_participatory_processes.participatory_processes_path
+      expect(page).to have_content(translated(participatory_process.title))
+    end
+  end
+
   context "when creating a participatory process" do
     let(:image1_filename) { "city.jpeg" }
     let(:image1_path) { Decidim::Dev.asset(image1_filename) }


### PR DESCRIPTION
Since Decidim v0.24, process groups have a title instead of a name.

Related to https://github.com/decidim/decidim/pull/6823