### PR TITLE
Fix users with any role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Following Semantic Versioning 2.
 
 ## next version:
 
+## Version 0.2.1 (PATCH)
+- Fix: Rename association to not override the one defined in HasPrivateUsers
+
 ## Version 0.2.0 (MINOR)
 - Allow to perform all actions in Conferences (decidim-conferences).
 - Allow to perform some actions in Participants (decidim-participants).

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ bin/rails decidim:generate_external_test_app
 cd spec/decidim_dummy_app/
 bundle exec rails decidim_department_admin:install:migrations
 RAILS_ENV=test bundle exec rails db:migrate
-sed -ie '/^  class Application < Rails::Application/a config.railties_order = [:main_app, ::Decidim::DepartmentAdmin::Engine, :all]' spec/decidim_dummy_app/config/application.rb
+sed -ie '/^  class Application < Rails::Application/a config.railties_order = [:main_app, ::Decidim::DepartmentAdmin::Engine, :all]' config/application.rb
 ```
 
 This last line modifies dummy_app's `config/application.rb` file to enforce railties ordering, adding:

--- a/app/decorators/decidim/assemblies_decorator.rb
+++ b/app/decorators/decidim/assemblies_decorator.rb
@@ -6,7 +6,8 @@
 #
 require_dependency "decidim/assembly"
 Decidim::Assembly.class_eval do
-  has_and_belongs_to_many :users,
+  has_and_belongs_to_many :users_with_any_role,
+                          class_name: "Decidim::User",
                           join_table: :decidim_assembly_user_roles,
                           foreign_key: :decidim_assembly_id,
                           association_foreign_key: :decidim_user_id,

--- a/app/decorators/decidim/conferences_decorator.rb
+++ b/app/decorators/decidim/conferences_decorator.rb
@@ -11,7 +11,8 @@ if defined?(Decidim::Conferences)
                class_name: "Decidim::Area",
                optional: true
 
-    has_and_belongs_to_many :users,
+    has_and_belongs_to_many :users_with_any_role,
+                            class_name: "Decidim::User",
                             join_table: :decidim_conference_user_roles,
                             foreign_key: :decidim_conference_id,
                             association_foreign_key: :decidim_user_id,

--- a/app/decorators/decidim/participatory_process_decorator.rb
+++ b/app/decorators/decidim/participatory_process_decorator.rb
@@ -6,7 +6,8 @@
 #
 require_dependency "decidim/participatory_process"
 Decidim::ParticipatoryProcess.class_eval do
-  has_and_belongs_to_many :users,
+  has_and_belongs_to_many :users_with_any_role,
+                          class_name: "Decidim::User",
                           join_table: :decidim_participatory_process_user_roles,
                           foreign_key: :decidim_participatory_process_id,
                           association_foreign_key: :decidim_user_id,

--- a/app/views/decidim/assemblies/admin/assemblies/index.html.erb
+++ b/app/views/decidim/assemblies/admin/assemblies/index.html.erb
@@ -83,7 +83,7 @@
                 <% end %>
               </td>
               <td>
-                <%= assembly.users.map(&:name).join(", ") %>
+                <%= assembly.users_with_any_role.map(&:name).join(", ") %>
               </td>
               <td>
                 <%= l(assembly.created_at, format: :short) %>

--- a/app/views/decidim/conferences/admin/conferences/index.html.erb
+++ b/app/views/decidim/conferences/admin/conferences/index.html.erb
@@ -52,7 +52,7 @@
                 <% end %>
               </td>
               <td>
-                <%= conference.users.map(&:name).join(", ") %>
+                <%= conference.users_with_any_role.map(&:name).join(", ") %>
               </td>
               <td>
                 <%= l conference.created_at, format: :short %>

--- a/app/views/decidim/participatory_processes/admin/participatory_processes/index.html.erb
+++ b/app/views/decidim/participatory_processes/admin/participatory_processes/index.html.erb
@@ -101,7 +101,7 @@
                 <% end %>
               </td>
               <td>
-                <%= process.users.map(&:name).join(", ") %>
+                <%= process.users_with_any_role.map(&:name).join(", ") %>
               </td>
               <td>
                 <%= l process.created_at, format: :short %>

--- a/lib/decidim/department_admin/version.rb
+++ b/lib/decidim/department_admin/version.rb
@@ -5,7 +5,7 @@ module Decidim
   module DepartmentAdmin
     # see CHANGELOG.md
     def self.version
-      "0.2.0"
+      "0.2.1"
     end
   end
 end


### PR DESCRIPTION
Renames association in `Assemblies`, `ParticipatoryProcess` and `Conferences` decorators to not override `Decidim::HasPrivateUsers#users`.