### PR TITLE
Fix department admin on "millora visualització rols"

### DIFF
--- a/app/decorators/decidim/area_decorator.rb
+++ b/app/decorators/decidim/area_decorator.rb
@@ -6,6 +6,7 @@ Decidim::Area.class_eval do
   before_destroy :abort_if_department_admins
 
   has_and_belongs_to_many :users,
+                          -> { where('\'department_admin\'=ANY("decidim_users"."roles")') },
                           join_table: :department_admin_areas,
                           foreign_key: :decidim_area_id,
                           association_foreign_key: :decidim_user_id,

--- a/app/views/decidim/admin/users/index.html.erb
+++ b/app/views/decidim/admin/users/index.html.erb
@@ -112,7 +112,11 @@ function changeFilter(el) {
                 </td>
                 <td><%= user.name %></td>
                 <td><%= user.email %></td>
-                <td><%= translated_attribute(user.areas.first&.name) %></td>
+                <td>
+                  <% if user.department_admin? %>
+                    <%= translated_attribute(user.areas.first&.name) %>
+                  <% end %>
+                </td>
                 <td>
                   <% if !role_and_title.nil? && !role_and_title[1].empty? %>
                     <%= role_and_title[1] %>


### PR DESCRIPTION
fix department admin on millora visualització rols when the user was in table department_admin_areas and has no role "department_admin" it shows like if it was a department_admin