### PR TITLE
upgrade version to 3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Following Semantic Versioning 2.
 
 ## next version:
 
+## Version 0.3.3 (PATCH)
+- Fix: Department admin on "millora visualització rols" when the user was in table department_admin_areas and has no role "department_admin" it shows like if it was a department_admin
+
 ## Version 0.3.2 (PATCH)
 - Fix: Rename association to not override the one defined in Decidim::HasPrivateUsers
 

--- a/lib/decidim/department_admin/version.rb
+++ b/lib/decidim/department_admin/version.rb
@@ -5,7 +5,7 @@ module Decidim
   module DepartmentAdmin
     # see CHANGELOG.md
     def self.version
-      "0.3.2"
+      "0.3.3"
     end
   end
 end


### PR DESCRIPTION
upgrade version for fix department admin on "millora visualització rols" when the user was in table department_admin_areas and has no role "department_admin" it shows like if it was a department_admin