### PR TITLE
Check if decidim-conferences is defined in a more reliable way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Following Semantic Versioning 2.
 ## next version:
 
 ## Version 0.3.4 (PATCH)
-- Fix check if `Dedicim::Conference` exists instead of checking `Dedicim::Conferences` #46 
+- Check if decidim-conferences is defined in a more reliable way
 
 ## Version 0.3.3 (PATCH)
 - Fix: Department admin on "millora visualització rols" when the user was in table department_admin_areas and has no role "department_admin" it shows like if it was a department_admin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Following Semantic Versioning 2.
 
 ## next version:
 
+## Version 0.3.4 (PATCH)
+- Fix check if `Dedicim::Conference` exists instead of checking `Dedicim::Conferences` #46 
+
 ## Version 0.3.3 (PATCH)
 - Fix: Department admin on "millora visualització rols" when the user was in table department_admin_areas and has no role "department_admin" it shows like if it was a department_admin
 

--- a/app/decorators/decidim/admin/users_controller_decorator.rb
+++ b/app/decorators/decidim/admin/users_controller_decorator.rb
@@ -68,7 +68,7 @@ require_dependency "decidim/admin/users_controller"
                    "published" => assembly.published?)
     end
 
-    if defined?(Decidim::Conferences)
+    if Decidim::DepartmentAdmin.conferences_defined?
       @user.conferences.each do |conference|
         area_name = conference.area&.name.try(:[], locale) || ""
 

--- a/app/decorators/decidim/area_decorator.rb
+++ b/app/decorators/decidim/area_decorator.rb
@@ -20,7 +20,7 @@ Decidim::Area.class_eval do
            class_name: "Assemblies",
            foreign_key: "decidim_area_id"
 
-  if defined?(Decidim::Conferences)
+  if Decidim::DepartmentAdmin.conferences_defined?
     has_many :conferences,
              class_name: "Conferences",
              foreign_key: "decidim_area_id"

--- a/app/decorators/decidim/conference_form_decorator.rb
+++ b/app/decorators/decidim/conference_form_decorator.rb
@@ -4,7 +4,7 @@
 # This decorator adds the attribute area_id to the ConferenceForm and
 # extends it with utility methods for the view and command.
 #
-if defined?(Decidim::Conference)
+if Decidim::DepartmentAdmin.conferences_defined?
   Decidim::Conferences::Admin::ConferenceForm.class_eval do
     attribute :area_id, Integer
 

--- a/app/decorators/decidim/conference_form_decorator.rb
+++ b/app/decorators/decidim/conference_form_decorator.rb
@@ -4,7 +4,7 @@
 # This decorator adds the attribute area_id to the ConferenceForm and
 # extends it with utility methods for the view and command.
 #
-if defined?(Decidim::Conferences)
+if defined?(Decidim::Conference)
   Decidim::Conferences::Admin::ConferenceForm.class_eval do
     attribute :area_id, Integer
 

--- a/app/decorators/decidim/conferences/admin/conferences_controller_decorator.rb
+++ b/app/decorators/decidim/conferences/admin/conferences_controller_decorator.rb
@@ -4,7 +4,7 @@
 # This decorator adds the capability to the controller to query conferences
 # filtering by User role `department_admin`.
 #
-if defined?(Decidim::Conferences)
+if defined?(Decidim::Conference)
   Decidim::Conferences::Admin::ConferencesController.class_eval do
     private
 

--- a/app/decorators/decidim/conferences/admin/conferences_controller_decorator.rb
+++ b/app/decorators/decidim/conferences/admin/conferences_controller_decorator.rb
@@ -4,7 +4,7 @@
 # This decorator adds the capability to the controller to query conferences
 # filtering by User role `department_admin`.
 #
-if defined?(Decidim::Conference)
+if Decidim::DepartmentAdmin.conferences_defined?
   Decidim::Conferences::Admin::ConferencesController.class_eval do
     private
 

--- a/app/decorators/decidim/conferences/create_conference_decorator.rb
+++ b/app/decorators/decidim/conferences/create_conference_decorator.rb
@@ -2,7 +2,7 @@
 
 # Intercepts the `call` method and forces the Area of the user if it is a
 # department_admin user.
-if defined?(Decidim::Conference)
+if Decidim::DepartmentAdmin.conferences_defined?
   Decidim::Conferences::Admin::CreateConference.class_eval do
     alias_method :original_call, :call
 

--- a/app/decorators/decidim/conferences/create_conference_decorator.rb
+++ b/app/decorators/decidim/conferences/create_conference_decorator.rb
@@ -2,7 +2,7 @@
 
 # Intercepts the `call` method and forces the Area of the user if it is a
 # department_admin user.
-if defined?(Decidim::Conferences)
+if defined?(Decidim::Conference)
   Decidim::Conferences::Admin::CreateConference.class_eval do
     alias_method :original_call, :call
 

--- a/app/decorators/decidim/conferences/permissions_decorator.rb
+++ b/app/decorators/decidim/conferences/permissions_decorator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-if defined?(Decidim::Conference)
+if Decidim::DepartmentAdmin.conferences_defined?
   Decidim::Conferences::Permissions.class_eval do
     # Intercept the `has_manageable_conferences?` method
     # always returns true if the user is a department_admin. Otherwise delegates to the original method.

--- a/app/decorators/decidim/conferences/permissions_decorator.rb
+++ b/app/decorators/decidim/conferences/permissions_decorator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-if defined?(Decidim::Conferences)
+if defined?(Decidim::Conference)
   Decidim::Conferences::Permissions.class_eval do
     # Intercept the `has_manageable_conferences?` method
     # always returns true if the user is a department_admin. Otherwise delegates to the original method.

--- a/app/decorators/decidim/conferences/update_conference_decorator.rb
+++ b/app/decorators/decidim/conferences/update_conference_decorator.rb
@@ -2,7 +2,7 @@
 
 # Intercepts the `call` method and forces the Area of the user if it is a
 # department_admin user.
-if defined?(Decidim::Conference)
+if Decidim::DepartmentAdmin.conferences_defined?
   Decidim::Conferences::Admin::UpdateConference.class_eval do
     alias_method :original_call, :call
 

--- a/app/decorators/decidim/conferences/update_conference_decorator.rb
+++ b/app/decorators/decidim/conferences/update_conference_decorator.rb
@@ -2,7 +2,7 @@
 
 # Intercepts the `call` method and forces the Area of the user if it is a
 # department_admin user.
-if defined?(Decidim::Conferences)
+if defined?(Decidim::Conference)
   Decidim::Conferences::Admin::UpdateConference.class_eval do
     alias_method :original_call, :call
 

--- a/app/decorators/decidim/conferences_decorator.rb
+++ b/app/decorators/decidim/conferences_decorator.rb
@@ -3,7 +3,8 @@
 #
 # This decorator adds required associations between Decidim::Conference and Area.
 #
-if defined?(Decidim::Conference)
+
+if Decidim::DepartmentAdmin.conferences_defined?
   require_dependency "decidim/conference"
   Decidim::Conference.class_eval do
     belongs_to :area,

--- a/app/decorators/decidim/conferences_decorator.rb
+++ b/app/decorators/decidim/conferences_decorator.rb
@@ -3,7 +3,7 @@
 #
 # This decorator adds required associations between Decidim::Conference and Area.
 #
-if defined?(Decidim::Conferences)
+if defined?(Decidim::Conference)
   require_dependency "decidim/conference"
   Decidim::Conference.class_eval do
     belongs_to :area,

--- a/app/decorators/decidim/conferences_with_user_role_decorator.rb
+++ b/app/decorators/decidim/conferences_with_user_role_decorator.rb
@@ -4,7 +4,7 @@
 # This decorator adds the capability to query participatory_processes
 # filtering by User role `department_admin`.
 #
-if defined?(Decidim::Conferences)
+if defined?(Decidim::Conference)
   Decidim::Conferences::ConferencesWithUserRole.class_eval do
     private
 

--- a/app/decorators/decidim/conferences_with_user_role_decorator.rb
+++ b/app/decorators/decidim/conferences_with_user_role_decorator.rb
@@ -4,7 +4,7 @@
 # This decorator adds the capability to query participatory_processes
 # filtering by User role `department_admin`.
 #
-if defined?(Decidim::Conference)
+if Decidim::DepartmentAdmin.conferences_defined?
   Decidim::Conferences::ConferencesWithUserRole.class_eval do
     private
 

--- a/app/decorators/decidim/user_decorator.rb
+++ b/app/decorators/decidim/user_decorator.rb
@@ -23,7 +23,7 @@ Decidim::User.class_eval do
                           foreign_key: :decidim_user_id,
                           association_foreign_key: :decidim_assembly_id,
                           validate: false
-  if defined?(Decidim::Conferences)
+  if Decidim::DepartmentAdmin.conferences_defined?
     has_and_belongs_to_many :conferences,
                             join_table: :decidim_conference_user_roles,
                             foreign_key: :decidim_user_id,

--- a/app/helpers/decidim/department_admin/application_helper.rb
+++ b/app/helpers/decidim/department_admin/application_helper.rb
@@ -43,7 +43,7 @@ module Decidim
       end
 
       def user_conferences_filtered(user, _locale, search_text)
-        return [] unless defined?(Decidim::Conferences)
+        return [] unless Decidim::DepartmentAdmin.conferences_defined?
 
         query = user.conferences
         query = query.where("lower(title->>?) like lower(?)", current_locale, "%#{search_text}%") if search_text.present?

--- a/app/permissions/decidim/conferences/participatory_space_permissions.rb
+++ b/app/permissions/decidim/conferences/participatory_space_permissions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-if defined?(Decidim::Conferences)
+if Decidim::DepartmentAdmin.conferences_defined?
   module Decidim
     module Conferences
       class ParticipatorySpacePermissions < Decidim::DepartmentAdmin::Permissions

--- a/app/queries/decidim/admin/user_admin_filter.rb
+++ b/app/queries/decidim/admin/user_admin_filter.rb
@@ -63,7 +63,7 @@ module Decidim
                         select id
                         from decidim_assemblies
                         where lower(title->>?) like lower(?)))
-          #{if defined?(Decidim::Conferences)
+          #{if Decidim::DepartmentAdmin.conferences_defined?)
               "or id in  ( select decidim_user_id
                           from decidim_conference_user_roles
                           where decidim_conference_id in (
@@ -73,7 +73,7 @@ module Decidim
             end}
         EOSQL
 
-        if defined?(Decidim::Conference)
+        if Decidim::DepartmentAdmin.conferences_defined?
           users.where(query, current_locale, containing_proces_name, current_locale, containing_proces_name, current_locale, containing_proces_name)
         else
           users.where(query, current_locale, containing_proces_name, current_locale, containing_proces_name)
@@ -85,7 +85,7 @@ module Decidim
 
         case role
         when "space_admin"
-          if defined?(Decidim::Conferences)
+          if Decidim::DepartmentAdmin.conferences_defined?
             users.where('"decidim_users"."id" in (select "decidim_participatory_process_user_roles"."decidim_user_id" from "decidim_participatory_process_user_roles")' \
                 ' or "decidim_users"."id" in (select "decidim_assembly_user_roles"."decidim_user_id" from "decidim_assembly_user_roles")' \
                 ' or "decidim_users"."id" in (select "decidim_conference_user_roles"."decidim_user_id" from "decidim_conference_user_roles")')

--- a/app/queries/decidim/admin/user_admin_filter.rb
+++ b/app/queries/decidim/admin/user_admin_filter.rb
@@ -63,7 +63,7 @@ module Decidim
                         select id
                         from decidim_assemblies
                         where lower(title->>?) like lower(?)))
-          #{if Decidim::DepartmentAdmin.conferences_defined?)
+          #{if Decidim::DepartmentAdmin.conferences_defined?
               "or id in  ( select decidim_user_id
                           from decidim_conference_user_roles
                           where decidim_conference_id in (

--- a/app/views/decidim/admin/users/index.html.erb
+++ b/app/views/decidim/admin/users/index.html.erb
@@ -139,7 +139,7 @@ function changeFilter(el) {
                 </td>
                 <td><%= l user.created_at, format: :short %></td>
                 <td class="table-list__actions">
-                  <% if user.participatory_processes.size > 0 || user.assemblies.size > 0 || (defined?(Decidim::Conferences) && user.conferences.size > 0) %>
+                  <% if user.participatory_processes.size > 0 || user.assemblies.size > 0 || (Decidim::DepartmentAdmin.conferences_defined? && user.conferences.size > 0) %>
                     <% if allowed_to? :preview, :user, user: user %>
                       <%= icon_link_to "eye", user_path(user.id), t("actions.preview", scope: "decidim.admin"), class: "action-icon--preview" %>
                     <% end %>

--- a/db/migrate/20210420143021_add_area_to_conferences.rb
+++ b/db/migrate/20210420143021_add_area_to_conferences.rb
@@ -2,6 +2,6 @@
 
 class AddAreaToConferences < ActiveRecord::Migration[5.2]
   def change
-    add_reference :decidim_conferences, :decidim_area, index: true if defined?(Decidim::Conferences)
+    add_reference :decidim_conferences, :decidim_area, index: true if Decidim::DepartmentAdmin.conferences_defined?
   end
 end

--- a/lib/decidim/department_admin.rb
+++ b/lib/decidim/department_admin.rb
@@ -8,5 +8,8 @@ module Decidim
   # This namespace holds the logic of the `DepartmentAdmin` module. This module
   # allows users to create department_admin in a participatory space.
   module DepartmentAdmin
+    def self.conferences_defined?
+      defined?(Decidim::Conferences::QueryExtensions)
+    end
   end
 end

--- a/lib/decidim/department_admin/engine.rb
+++ b/lib/decidim/department_admin/engine.rb
@@ -67,7 +67,7 @@ module Decidim
         AssembliesAdminApplicationControllerPermissions = Class.new(::Decidim::DepartmentAdmin::Permissions)
         register_new_permissions_for(artifact, AssembliesAdminApplicationControllerPermissions)
 
-        if defined?(Decidim::Conferences)
+        if defined?(Decidim::Conference)
           # **
           # Modify decidim-conferences permissions registry
           # **
@@ -99,7 +99,7 @@ module Decidim
         # override assemblies space manifest permissions with DepartmentAdmin's one
         manifest = Decidim.find_participatory_space_manifest(:assemblies)
         manifest.permissions_class_name = "Decidim::Assemblies::ParticipatorySpacePermissions"
-        if defined?(Decidim::Conferences)
+        if defined?(Decidim::Conference)
           # override conferences space manifest permissions with DepartmentAdmin's one
           manifest = Decidim.find_participatory_space_manifest(:conferences)
           manifest.permissions_class_name = "Decidim::Conferences::ParticipatorySpacePermissions"

--- a/lib/decidim/department_admin/engine.rb
+++ b/lib/decidim/department_admin/engine.rb
@@ -67,7 +67,7 @@ module Decidim
         AssembliesAdminApplicationControllerPermissions = Class.new(::Decidim::DepartmentAdmin::Permissions)
         register_new_permissions_for(artifact, AssembliesAdminApplicationControllerPermissions)
 
-        if defined?(Decidim::Conference)
+        if Decidim::DepartmentAdmin.conferences_defined?
           # **
           # Modify decidim-conferences permissions registry
           # **
@@ -99,7 +99,7 @@ module Decidim
         # override assemblies space manifest permissions with DepartmentAdmin's one
         manifest = Decidim.find_participatory_space_manifest(:assemblies)
         manifest.permissions_class_name = "Decidim::Assemblies::ParticipatorySpacePermissions"
-        if defined?(Decidim::Conference)
+        if Decidim::DepartmentAdmin.conferences_defined?
           # override conferences space manifest permissions with DepartmentAdmin's one
           manifest = Decidim.find_participatory_space_manifest(:conferences)
           manifest.permissions_class_name = "Decidim::Conferences::ParticipatorySpacePermissions"

--- a/lib/decidim/department_admin/version.rb
+++ b/lib/decidim/department_admin/version.rb
@@ -5,7 +5,7 @@ module Decidim
   module DepartmentAdmin
     # see CHANGELOG.md
     def self.version
-      "0.3.3"
+      "0.3.4"
     end
   end
 end

--- a/spec/system/department_admin_should_be_able_to_access_admin_dashboard_spec.rb
+++ b/spec/system/department_admin_should_be_able_to_access_admin_dashboard_spec.rb
@@ -57,7 +57,6 @@ describe "Department admin should be able to access Admin Dashboard", type: :sys
     # TODO: not supported at the moment
     # it "should be able to access 'Initiatives'"
     # it "should be able to access 'Consultations'"
-    # it "should be able to access 'Conferences'"
   end
 
   context "when accessing the dashboard some left menu elements should NOT be accessible" do


### PR DESCRIPTION
Depending how gems are loaded `defined?(Dedicim::Conferences)` may be `true` even when the Decidim application does not declare any dependency to `decidim-conferences`.
To avoid that problem `defined?(Decidim::Conferences::QueryExtensions)` must be used instead because that class will not be required if `decidim-conferences` is not a dependency.

The problem manifests with stacktraces like the following:
```ruby
=> Booting Puma
=> Rails 5.2.6 application starting in development 
=> Run `rails server -h` for more startup options
Exiting
Traceback (most recent call last):
	57: from bin/rails:11:in `<main>'
	56: from bin/rails:11:in `require'
	55: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-5.2.6/lib/rails/commands.rb:18:in `<top (required)>'
	54: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-5.2.6/lib/rails/command.rb:46:in `invoke'
	53: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-5.2.6/lib/rails/command/base.rb:69:in `perform'
	52: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor.rb:392:in `dispatch'
	51: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor/invocation.rb:127:in `invoke_command'
	50: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor/command.rb:27:in `run'
	49: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-5.2.6/lib/rails/commands/server/server_command.rb:142:in `perform'
	48: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-5.2.6/lib/rails/commands/server/server_command.rb:142:in `tap'
	47: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-5.2.6/lib/rails/commands/server/server_command.rb:147:in `block in perform'
	46: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-5.2.6/lib/rails/commands/server/server_command.rb:51:in `start'
	45: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-5.2.6/lib/rails/commands/server/server_command.rb:89:in `log_to_stdout'
	44: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rack-2.2.3/lib/rack/server.rb:422:in `wrapped_app'
	43: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-5.2.6/lib/rails/commands/server/server_command.rb:27:in `app'
	42: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rack-2.2.3/lib/rack/server.rb:249:in `app'
	41: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rack-2.2.3/lib/rack/server.rb:349:in `build_app_and_options_from_config'
	40: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rack-2.2.3/lib/rack/builder.rb:66:in `parse_file'
	39: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rack-2.2.3/lib/rack/builder.rb:105:in `load_file'
	38: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rack-2.2.3/lib/rack/builder.rb:116:in `new_from_string'
	37: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rack-2.2.3/lib/rack/builder.rb:116:in `eval'
	36: from config.ru:5:in `block in <main>'
	35: from config.ru:5:in `require_relative'
	34: from /home/oliver/prog/decidim/gencat/participa-gencat/config/environment.rb:7:in `<top (required)>'
	33: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-5.2.6/lib/rails/application.rb:361:in `initialize!'
	32: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-5.2.6/lib/rails/initializable.rb:60:in `run_initializers'
	31: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/2.7.0/tsort.rb:205:in `tsort_each'
	30: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/2.7.0/tsort.rb:226:in `tsort_each'
	29: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/2.7.0/tsort.rb:347:in `each_strongly_connected_component'
	28: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/2.7.0/tsort.rb:347:in `call'
	27: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/2.7.0/tsort.rb:347:in `each'
	26: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/2.7.0/tsort.rb:349:in `block in each_strongly_connected_component'
	25: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/2.7.0/tsort.rb:431:in `each_strongly_connected_component_from'
	24: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/2.7.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
	23: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/2.7.0/tsort.rb:228:in `block in tsort_each'
	22: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-5.2.6/lib/rails/initializable.rb:61:in `block in run_initializers'
	21: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-5.2.6/lib/rails/initializable.rb:32:in `run'
	20: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-5.2.6/lib/rails/initializable.rb:32:in `instance_exec'
	19: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-5.2.6/lib/rails/application/finisher.rb:63:in `block in <module:Finisher>'
	18: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.6/lib/active_support/reloader.rb:89:in `prepare!'
	17: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.6/lib/active_support/callbacks.rb:131:in `run_callbacks'
	16: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.6/lib/active_support/callbacks.rb:513:in `invoke_before'
	15: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.6/lib/active_support/callbacks.rb:513:in `each'
	14: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.6/lib/active_support/callbacks.rb:513:in `block in invoke_before'
	13: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.6/lib/active_support/callbacks.rb:199:in `block in halting'
	12: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.6/lib/active_support/callbacks.rb:605:in `block in default_terminator'
	11: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.6/lib/active_support/callbacks.rb:605:in `catch'
	10: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.6/lib/active_support/callbacks.rb:606:in `block (2 levels) in default_terminator'
	 9: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.6/lib/active_support/callbacks.rb:198:in `block (2 levels) in halting'
	 8: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.6/lib/active_support/callbacks.rb:426:in `block in make_lambda'
	 7: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.6/lib/active_support/callbacks.rb:426:in `instance_exec'
	 6: from /home/oliver/prog/decidim/gencat/decidim-department_admin/lib/decidim/department_admin/engine.rb:89:in `block in <class:Engine>'
	 5: from /home/oliver/prog/decidim/gencat/decidim-department_admin/lib/decidim/department_admin/engine.rb:89:in `each'
	 4: from /home/oliver/prog/decidim/gencat/decidim-department_admin/lib/decidim/department_admin/engine.rb:90:in `block (2 levels) in <class:Engine>'
	 3: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.6/lib/active_support/dependencies/interlock.rb:13:in `loading'
	 2: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.6/lib/active_support/concurrency/share_lock.rb:151:in `exclusive'
	 1: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.6/lib/active_support/dependencies/interlock.rb:14:in `block in loading'
/home/oliver/prog/decidim/gencat/decidim-department_admin/app/decorators/decidim/conferences/update_conference_decorator.rb:6:in `<top (required)>': uninitialized constant Decidim::Conferences::Admin::UpdateConference (NameError)
=> Booting Puma
=> Rails 5.2.6 application starting in development 
=> Run `rails server -h` for more startup options
Exiting
Traceback (most recent call last):
	57: from bin/rails:11:in `<main>'
	56: from bin/rails:11:in `require'
	55: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-5.2.6/lib/rails/commands.rb:18:in `<top (required)>'
	54: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-5.2.6/lib/rails/command.rb:46:in `invoke'
	53: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-5.2.6/lib/rails/command/base.rb:69:in `perform'
	52: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor.rb:392:in `dispatch'
	51: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor/invocation.rb:127:in `invoke_command'
	50: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor/command.rb:27:in `run'
	49: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-5.2.6/lib/rails/commands/server/server_command.rb:142:in `perform'
	48: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-5.2.6/lib/rails/commands/server/server_command.rb:142:in `tap'
	47: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-5.2.6/lib/rails/commands/server/server_command.rb:147:in `block in perform'
	46: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-5.2.6/lib/rails/commands/server/server_command.rb:51:in `start'
	45: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-5.2.6/lib/rails/commands/server/server_command.rb:89:in `log_to_stdout'
	44: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rack-2.2.3/lib/rack/server.rb:422:in `wrapped_app'
	43: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-5.2.6/lib/rails/commands/server/server_command.rb:27:in `app'
	42: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rack-2.2.3/lib/rack/server.rb:249:in `app'
	41: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rack-2.2.3/lib/rack/server.rb:349:in `build_app_and_options_from_config'
	40: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rack-2.2.3/lib/rack/builder.rb:66:in `parse_file'
	39: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rack-2.2.3/lib/rack/builder.rb:105:in `load_file'
	38: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rack-2.2.3/lib/rack/builder.rb:116:in `new_from_string'
	37: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rack-2.2.3/lib/rack/builder.rb:116:in `eval'
	36: from config.ru:5:in `block in <main>'
	35: from config.ru:5:in `require_relative'
	34: from /home/oliver/prog/decidim/gencat/participa-gencat/config/environment.rb:7:in `<top (required)>'
	33: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-5.2.6/lib/rails/application.rb:361:in `initialize!'
	32: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-5.2.6/lib/rails/initializable.rb:60:in `run_initializers'
	31: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/2.7.0/tsort.rb:205:in `tsort_each'
	30: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/2.7.0/tsort.rb:226:in `tsort_each'
	29: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/2.7.0/tsort.rb:347:in `each_strongly_connected_component'
	28: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/2.7.0/tsort.rb:347:in `call'
	27: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/2.7.0/tsort.rb:347:in `each'
	26: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/2.7.0/tsort.rb:349:in `block in each_strongly_connected_component'
	25: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/2.7.0/tsort.rb:431:in `each_strongly_connected_component_from'
	24: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/2.7.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
	23: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/2.7.0/tsort.rb:228:in `block in tsort_each'
	22: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-5.2.6/lib/rails/initializable.rb:61:in `block in run_initializers'
	21: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-5.2.6/lib/rails/initializable.rb:32:in `run'
	20: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-5.2.6/lib/rails/initializable.rb:32:in `instance_exec'
	19: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-5.2.6/lib/rails/application/finisher.rb:63:in `block in <module:Finisher>'
	18: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.6/lib/active_support/reloader.rb:89:in `prepare!'
	17: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.6/lib/active_support/callbacks.rb:131:in `run_callbacks'
	16: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.6/lib/active_support/callbacks.rb:513:in `invoke_before'
	15: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.6/lib/active_support/callbacks.rb:513:in `each'
	14: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.6/lib/active_support/callbacks.rb:513:in `block in invoke_before'
	13: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.6/lib/active_support/callbacks.rb:199:in `block in halting'
	12: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.6/lib/active_support/callbacks.rb:605:in `block in default_terminator'
	11: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.6/lib/active_support/callbacks.rb:605:in `catch'
	10: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.6/lib/active_support/callbacks.rb:606:in `block (2 levels) in default_terminator'
	 9: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.6/lib/active_support/callbacks.rb:198:in `block (2 levels) in halting'
	 8: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.6/lib/active_support/callbacks.rb:426:in `block in make_lambda'
	 7: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.6/lib/active_support/callbacks.rb:426:in `instance_exec'
	 6: from /home/oliver/prog/decidim/gencat/decidim-department_admin/lib/decidim/department_admin/engine.rb:89:in `block in <class:Engine>'
	 5: from /home/oliver/prog/decidim/gencat/decidim-department_admin/lib/decidim/department_admin/engine.rb:89:in `each'
	 4: from /home/oliver/prog/decidim/gencat/decidim-department_admin/lib/decidim/department_admin/engine.rb:90:in `block (2 levels) in <class:Engine>'
	 3: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.6/lib/active_support/dependencies/interlock.rb:13:in `loading'
	 2: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.6/lib/active_support/concurrency/share_lock.rb:151:in `exclusive'
	 1: from /home/oliver/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.6/lib/active_support/dependencies/interlock.rb:14:in `block in loading'
/home/oliver/prog/decidim/gencat/decidim-department_admin/app/decorators/decidim/conferences/update_conference_decorator.rb:6:in `<top (required)>': uninitialized constant Decidim::Conferences::Admin::UpdateConference (NameError)
```